### PR TITLE
Add bionic support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
+  - os: linux
+    dist: bionic
+    sudo: required
   - os: osx
   allow_failures:
   - os: osx

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 TARGET := main
 
 OS := $(shell uname -s)
+VERSION := $(shell lsb_release -rs)
 LATEXMK := $(shell command -v latexmk 2> /dev/null)
 LATEXMK_OPTION := -time -recorder -rules
 LATEXMK_EXEC := latexmk $(LATEXMK_OPTION)
@@ -38,7 +39,11 @@ install:
 ifndef LATEXMK
 	@echo 'installing components...'
 ifeq ($(OS), Linux)
+ifeq ($(VERSION), 18.04)
+	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra texlive-lang-japanese xdvik-ja gv latexmk
+else
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
+endif
 endif
 ifeq ($(OS), Darwin)
 	brew tap caskroom/cask && brew cask install -v mactex && sudo tlmgr update --self --all

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ifndef LATEXMK
 	@echo 'installing components...'
 ifeq ($(OS), Linux)
 ifeq ($(VERSION), 18.04)
-	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra texlive-lang-japanese xdvik-ja gv latexmk
+	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra texlive-lang-cjk xdvik-ja gv latexmk
 else
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
 endif


### PR DESCRIPTION
On ubuntu 18.04, `make` command does not work because `dvipsk-ja` package does not exist.

Therefore, I added `texlive-lang-japanese` package instead of `dvipsk-ja` package.
I also added test for ubuntu 18.04

You can see that the travis test failed at the first commit and passed at the second commit.
https://github.com/708yamaguchi/si-template-1/commits/add-bionic

I am not sure `texlive-lang-japanese` is minimum package as an alternative to `dvipsk-ja`
I would like to hear your opinion.

We may also need to modify other repositories, such as ieee-template