### PR TITLE
Support Precise in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ install:
 ifndef LATEXMK
 	@echo 'installing components...'
 ifeq ($(OS), Linux)
-ifeq ($(VERSION), 14.04)
+ifeq ($(VERSION), 12.04)
+	sudo apt-get install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
+else ifeq ($(VERSION), 14.04)
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja dvipsk-ja gv latexmk
 else
 	sudo apt install -y -qq texlive texlive-lang-cjk texlive-lang-japanese texlive-science texlive-fonts-recommended texlive-fonts-extra xdvik-ja gv latexmk

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Latex template for SICE-SI
 # only for ubuntu 12.04
 $ sudo apt-add-repository ppa:texlive-backports/ppa
 $ sudo apt-get update
+$ sudo apt-get install lsb-release
 ```
 
 ### 2. Edit LaTeX files


### PR DESCRIPTION
Adding travis test of Precise seems a little bit difficult:
https://travis-ci.org/github/pazeshun/si-template/jobs/689483308
We have to introduce a special solution (e.g., using docker instead of `dist: precise`), but I think we don't have to make such effort for so old distribution.
I just confirmed this PR currently works on Precise docker on my local PC, and that's enough, I think.